### PR TITLE
fix: fix VR reading of settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,10 @@ configure_file(
 execute_process(COMMAND powershell -ExecutionPolicy Bypass -File "${CMAKE_CURRENT_SOURCE_DIR}/!Update.ps1" "SOURCEGEN" "${PROJECT_VERSION}" "${CMAKE_CURRENT_BINARY_DIR}")
 include(${CMAKE_CURRENT_BINARY_DIR}/sourcelist.cmake)
 source_group(
-	TREE 
-		${CMAKE_CURRENT_SOURCE_DIR}
-	FILES 
-		${SOURCES}
+	TREE
+	${CMAKE_CURRENT_SOURCE_DIR}
+	FILES
+	${SOURCES}
 )
 
 source_group(
@@ -90,63 +90,63 @@ find_package(spdlog CONFIG REQUIRED)
 add_library(
 	${PROJECT_NAME}
 	SHARED
-		${SOURCES}
-		${CMAKE_CURRENT_BINARY_DIR}/include/Version.h
-		${CMAKE_CURRENT_BINARY_DIR}/version.rc
-		.clang-format
-		vcpkg.json
+	${SOURCES}
+	${CMAKE_CURRENT_BINARY_DIR}/include/Version.h
+	${CMAKE_CURRENT_BINARY_DIR}/version.rc
+	.clang-format
+	vcpkg.json
 )
 
 # include dir
 target_include_directories(
 	${PROJECT_NAME}
 	PRIVATE
-		${CMAKE_CURRENT_BINARY_DIR}/include
-		${CMAKE_CURRENT_SOURCE_DIR}/include
-		${CMAKE_CURRENT_SOURCE_DIR}/src
+	${CMAKE_CURRENT_BINARY_DIR}/include
+	${CMAKE_CURRENT_SOURCE_DIR}/include
+	${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
 # linkage
 target_link_libraries(
-	${PROJECT_NAME} 
+	${PROJECT_NAME}
 	PRIVATE
-		CommonLibSSE::CommonLibSSE
-		DKUtil::DKUtil
-		spdlog::spdlog
+	CommonLibSSE::CommonLibSSE
+	DKUtil::DKUtil
+	spdlog::spdlog
 )
 
 # compiler def
-if (MSVC)
+if(MSVC)
 	add_compile_definitions(_UNICODE)
 
 	target_compile_options(
 		${PROJECT_NAME}
 		PRIVATE
-			/MP
-			/await
-			/W0
-			/WX
-			/permissive-
-			/Zc:alignedNew
-			/Zc:auto
-			/Zc:__cplusplus
-			/Zc:externC
-			/Zc:externConstexpr
-			/Zc:forScope
-			/Zc:hiddenFriend
-			/Zc:implicitNoexcept
-			/Zc:lambda
-			/Zc:noexceptTypes
-			/Zc:preprocessor
-			/Zc:referenceBinding
-			/Zc:rvalueCast
-			/Zc:sizedDealloc
-			/Zc:strictStrings
-			/Zc:ternary
-			/Zc:threadSafeInit
-			/Zc:trigraphs
-			/Zc:wchar_t
-			/wd4200 # nonstandard extension used : zero-sized array in struct/union
+		/MP
+		/await
+		/W0
+		/WX
+		/permissive-
+		/Zc:alignedNew
+		/Zc:auto
+		/Zc:__cplusplus
+		/Zc:externC
+		/Zc:externConstexpr
+		/Zc:forScope
+		/Zc:hiddenFriend
+		/Zc:implicitNoexcept
+		/Zc:lambda
+		/Zc:noexceptTypes
+		/Zc:preprocessor
+		/Zc:referenceBinding
+		/Zc:rvalueCast
+		/Zc:sizedDealloc
+		/Zc:strictStrings
+		/Zc:ternary
+		/Zc:threadSafeInit
+		/Zc:trigraphs
+		/Zc:wchar_t
+		/wd4200 # nonstandard extension used : zero-sized array in struct/union
 	)
 endif()
 
@@ -154,28 +154,28 @@ endif()
 target_precompile_headers(
 	${PROJECT_NAME}
 	PRIVATE
-		src/PCH.h
+	src/PCH.h
 )
 
 # post build event
 add_custom_command(
-	TARGET 
-		${PROJECT_NAME}
+	TARGET
+	${PROJECT_NAME}
 	POST_BUILD
-		COMMAND 
-			powershell -NoProfile -ExecutionPolicy Bypass -File "${CMAKE_CURRENT_SOURCE_DIR}/!Update.ps1" "COPY" "${PROJECT_VERSION}" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$(ConfigurationName)" "${PROJECT_NAME}" "${ANNIVERSARY_EDITION}"
-		COMMENT 
-			"Updating project :))"
+	COMMAND
+	powershell -NoProfile -ExecutionPolicy Bypass -File " ${CMAKE_CURRENT_SOURCE_DIR}/!Update.ps1" "COPY" "${PROJECT_VERSION}" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$(ConfigurationName)" "${PROJECT_NAME}" "${ANNIVERSARY_EDITION} "
+	COMMENT
+	" Updating project :))"
 )
 
 # called via !Rebuild.ps1
 if(DEFINED GROUP)
-set_target_properties(
-	${PROJECT_NAME}
-	PROPERTIES
-	FOLDER
-	${GROUP}
-)
+	set_target_properties(
+		${PROJECT_NAME}
+		PROPERTIES
+		FOLDER
+		${GROUP}
+	)
 endif()
 
 # https://gitlab.kitware.com/cmake/cmake/-/issues/24922#note_1371990

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,3 +177,23 @@ set_target_properties(
 	${GROUP}
 )
 endif()
+
+# https://gitlab.kitware.com/cmake/cmake/-/issues/24922#note_1371990
+if(MSVC_VERSION GREATER_EQUAL 1936 AND MSVC_IDE) # 17.6+
+	# When using /std:c++latest, "Build ISO C++23 Standard Library Modules" defaults to "Yes".
+	# Default to "No" instead.
+	#
+	# As of CMake 3.26.4, there isn't a way to control this property
+	# (https://gitlab.kitware.com/cmake/cmake/-/issues/24922),
+	# We'll use the MSBuild project system instead
+	# (https://learn.microsoft.com/en-us/cpp/build/reference/vcxproj-file-structure)
+	file(CONFIGURE OUTPUT "${CMAKE_BINARY_DIR}/Directory.Build.props" CONTENT [==[
+<Project>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <BuildStlModules>false</BuildStlModules>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>
+]==] @ONLY)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include(GNUInstallDirs)
 # info
 project(
 	CombatPathingRevolution
-	VERSION 0.30.0
+	VERSION 0.30.1
 	LANGUAGES CXX
 )
 

--- a/src/Backoff_Hook.h
+++ b/src/Backoff_Hook.h
@@ -36,8 +36,7 @@ namespace CombatPathing
 				REL::RelocationID(SE_FuncID, AE_FuncID).address(),
 				REL::Relocate(std::make_pair(SE_OffsetL, SE_OffsetH), std::make_pair(AE_OffsetL, AE_OffsetH)),
 				FUNC_INFO(RescaleBackoffMinDistanceMult),
-				&RelocatePointer,
-				nullptr);
+				&RelocatePointer);
 
 			handle->Enable();
 

--- a/src/Backoff_Hook.h
+++ b/src/Backoff_Hook.h
@@ -36,7 +36,8 @@ namespace CombatPathing
 				REL::RelocationID(SE_FuncID, AE_FuncID).address(),
 				REL::Relocate(std::make_pair(SE_OffsetL, SE_OffsetH), std::make_pair(AE_OffsetL, AE_OffsetH)),
 				FUNC_INFO(RescaleBackoffMinDistanceMult),
-				&RelocatePointer);
+				&RelocatePointer,
+				nullptr);
 
 			handle->Enable();
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name":  "combatpathingrevolution",
-    "version-string":  "0.30.0",
+    "version-string":  "0.30.1",
     "description":  "",
     "license":  "MIT",
     "dependencies": [


### PR DESCRIPTION
This pins the dependencies but also fixes a bug found with the VR version where ini settings were ignored. This may have been compiled with different versions of DKUtil due to a lack of a pin.

Please note that the DKUtil is non-standard to address CTDs discovered moving to the latest in the reverted a15abe8ee1275980b889da0eb0369190793ddb50 as the API changed. 

The long term fix may be to determine the cause of the CTD.